### PR TITLE
Performace boost.  Large messages and attachments 

### DIFF
--- a/lib/eximap/imap/client.ex
+++ b/lib/eximap/imap/client.ex
@@ -95,7 +95,10 @@ defmodule Eximap.Imap.Client do
       [_match | [size]] = Regex.run(@literal, other_parts)
       size = String.to_integer(size)
       [head, tail] = String.split(other_parts, @literal, parts: 2)
-      literal = for i <- 0..(size - 1), do: Enum.at(String.codepoints(tail), i)
+      # literal = for i <- 0..(size - 1), do: Enum.at(String.codepoints(tail), i)
+      # Performace boost.  Large messages and attachments killed this and took > 2 minutes for a 40K attachment.
+      cp=String.codepoints(tail)
+      {literal, _post_literal_cp} = Enum.split(cp,size)
       literal = to_string(literal)
       {_, post_literal} = String.split_at(tail, String.length(literal))
 

--- a/lib/eximap/imap/request.ex
+++ b/lib/eximap/imap/request.ex
@@ -14,7 +14,7 @@ defmodule Eximap.Imap.Request do
     iex> req = Eximap.Imap.Request.noop()
     iex> Eximap.Imap.Client.execute(pid, req) |> Map.from_struct()
     %{body: [%{}], error: nil,
-             message: "NOOP completed (0.000 + 0.000 secs).", partial: false,
+             message: "NOOP completed (0.001 + 0.000 secs).", partial: false,
              request: %Eximap.Imap.Request{command: "NOOP", params: [],
               tag: "EX1"}, status: "OK"}
 


### PR DESCRIPTION
 Large messages and attachments took > 2 minutes for a 40K attachment.