### PR TITLE
trim trailing whitespace from raw requests

### DIFF
--- a/lib/eximap/imap/request.ex
+++ b/lib/eximap/imap/request.ex
@@ -5,7 +5,21 @@ defmodule Eximap.Imap.Request do
   defstruct tag: "TAG", command: nil, params: []
 
   def add_tag(req, tag), do: %Eximap.Imap.Request{req | tag: tag}
-  def raw(req), do: "#{req.tag} #{req.command} #{Enum.join(req.params, " ")}\r\n"
+
+  def raw(req) do
+    params =
+      case req.params do
+        [] -> nil
+        _ -> Enum.join(req.params, " ")
+      end
+     s =
+      [req.tag, req.command, params]
+      |> Enum.filter(& &1)
+      |> Enum.map(&to_string(&1))
+      |> Enum.join(" ")
+     s <> "\r\n"
+  end
+
 
   @doc ~S"""
   The NOOP command always succeeds.  It does nothing.

--- a/test/eximap/request_test.exs
+++ b/test/eximap/request_test.exs
@@ -1,0 +1,16 @@
+defmodule RequestTest do
+  use ExUnit.Case
+  alias Eximap.Imap.Request
+
+  test "NOOP shouldnt have trailing whitespace before CRLF" do
+    noop = Request.noop()
+    assert Request.raw(noop) == "#{noop.tag} NOOP\r\n"
+  end
+
+  test "trailing CRLFs in APPEND params shouldnt be trimmed" do
+    text = "Delivered-To: test@localhost\r\n\r\nTest\r\n"
+    msize = byte_size(text)
+    req = Request.append("INBOX", ["\{#{msize}+\}\r\n", text])
+    assert Request.raw(req) == "#{req.tag} APPEND INBOX " <> "\{#{msize}+\}\r\n" <> text <> "\r\n"
+  end
+end


### PR DESCRIPTION
`TAG NOOP \r\n`
results in `invalid syntax` response both from gmail and yandex imap servers
it should be just
`TAG NOOP\r\n`