### PR TITLE
feat: add cacerts in ssl config

### DIFF
--- a/lib/eximap/imap/client.ex
+++ b/lib/eximap/imap/client.ex
@@ -16,7 +16,7 @@ defmodule Eximap.Imap.Client do
   end
 
   def init(state) do
-    opts = [:binary, active: false]
+    opts = [:binary, active: false, verify: :verify_peer, cacerts: :certifi.cacerts()]
     host = Application.get_env(:eximap, :incoming_mail_server) |> to_charlist
     port = Application.get_env(:eximap, :incoming_port)
     account = Application.get_env(:eximap, :account)

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Eximap.Mixfile do
       {:credo, "~> 0.8.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.7.4", only: [:dev, :test], runtime: false},
+      {:certifi, "~> 2.12.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Eximap.Mixfile do
       {:credo, "~> 0.8.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.7.4", only: [:dev, :test], runtime: false},
-      {:certifi, "~> 2.12.0"}
+      {:certifi, "~> 2.12"}
     ]
   end
 


### PR DESCRIPTION
Since OTP version 26, :verify_peer is enable but no CA certificates are provided. Certificates are added in configuration thanks to the `:certifi` lib.